### PR TITLE
NH | removing hard-coded centring on flex-cards

### DIFF
--- a/code/thrive-design-stylesheet-new.css
+++ b/code/thrive-design-stylesheet-new.css
@@ -1668,8 +1668,6 @@ body.ribbit .flex-cards>[class*="col-"] {
     flex: 1;
     justify-content: unset;
     height: 100%;
-    align-items: center;
-    text-align: center;
 }
 
 /*** removing margin on final paragraph ***/


### PR DESCRIPTION
Removing the hard-coded centring on flex-cards so the user can change the text alignment in the WYSIWYG.