### PR TITLE
NH | removing slide class from JS

### DIFF
--- a/code/thrive-design-general.js
+++ b/code/thrive-design-general.js
@@ -107,20 +107,6 @@ function handleSlider() {
         nextArrow: '<button type="button" class="slick-arrow next-arrow"><i class="fa-solid fa-chevron-right"></i></button>'
     });
 
-    $('.slide').wrapAll('<div class="slider"></div>');
-
-    $('.slider:not(.hero)').slick({
-        dots: true,
-        arrows: true,
-        infinite: true,
-        fade: false,
-        autoplay: true,
-        slidesToShow: 1,
-        slidesToScroll: 1,
-        prevArrow: '<button type="button" class="slick-arrow prev-arrow slick-prev"><i class="fa-solid fa-chevron-left"></i></button>',
-        nextArrow: '<button type="button" class="slick-arrow next-arrow slick-next"><i class="fa-solid fa-chevron-right"></i></button>'
-    });
-
     $('.make-carousel-tiles ul').slick({
         dots: false,
         arrows: true,


### PR DESCRIPTION
I'm removing the .slide component of the slider JS as it conflicts with the native HL slider functionality. Assigning to @eCM-MDykeman as you did a lot of the carousel work and seem best positioned to confirm this is a safe change to make.