### PR TITLE
Update thrive-design-stylesheet-new.css

### DIFF
--- a/code/thrive-design-stylesheet-new.css
+++ b/code/thrive-design-stylesheet-new.css
@@ -970,6 +970,10 @@ body.ribbit .arrow-link-standalone a.link-standalone {
     font-weight: 600;
 }
 
+.make-arrow-link em a {
+    color: inherit;
+}
+
 .col-md-3 .make-arrow-link em a {
     font-size: 14px;
 }


### PR DESCRIPTION
color: inherit ensures that the color of links and icons inside .make-arrow-link adapt to the parent element’s color, preventing mismatches across different themed backgrounds, as we have already setup the text colors for the backgrounds this should fix the static color: var(--hl-bs--link) on background colors while leaving other elements intact


https://econversetest.connectedcommunity.org/wds-staging/general-templates/cailee-test-page
