### PR TITLE
Adding in slide-content as an option

### DIFF
--- a/code/thrive-design-general.js
+++ b/code/thrive-design-general.js
@@ -95,7 +95,14 @@ function handleSlider() {
 
     $('.memberhome-slide').wrapAll('<div class="memberhome-slider"></div>');
 
-    $('.memberhome-slider').slick({
+    $('.slide-content').wrapAll('<div class="slide-content-wrapper" />');
+
+        // Check if any element has the class 'white-text' and add it to 'slide-content-wrapper'
+    if ($('.slide-content').hasClass('white-text')) {
+        $('.slide-content-wrapper').addClass('white-text');
+    }
+
+    $('.memberhome-slider,.slide-content-wrapper').slick({
         dots: true,
         arrows: true,
         infinite: true,

--- a/code/thrive-design-stylesheet-new.css
+++ b/code/thrive-design-stylesheet-new.css
@@ -2653,6 +2653,34 @@ body.ribbit.memberhome #MPFooterLink {
     padding: 0;
 }
 
+
+/************ basic-slider *************/
+
+.slide-content-wrapper .slick-arrow {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 44px;
+    background: transparent;
+    border: 0;
+    z-index: 1;
+    color: #000;
+    opacity: 0.7;
+}
+
+.slide-content-wrapper:has(.white-text) .slick-arrow {
+    color: #fff;
+}
+
+.slide-content-wrapper .prev-arrow {
+    left: -45px;
+}
+
+.slide-content-wrapper .next-arrow {
+    right: -45px;
+}
+
+
 /************ hero *************/
 
 .hero {


### PR DESCRIPTION
Adding in a generic slide class to wds.

After some internal team discussion I opted with ".slide-content" as the class to add in a generic slide functionality while avoiding the ".slide" class present in base HL code. 

Trying a slightly new approach to light/dark colour options. I have added a condition that checks for the presence of "white-text" on slide-content items and if present the check adds "white-text" to the slide-content-wrapper which is then used to add white next/prev buttons to the slider. 

Justification for this was to add in a method to apply contrast depending on the background row colour while not having to add in an entirely new class to the styling but leveraging an existing class in a slightly different way.

Default colour of next/prev buttons is black.