### PR TITLE
Revert "Solving td50"

### DIFF
--- a/code/thrive-design-stylesheet-new.css
+++ b/code/thrive-design-stylesheet-new.css
@@ -1286,22 +1286,13 @@ body.ribbit #MPOuterMost #MPOuter .bg-secondary-light .ContentItemHtml:not(.card
     color: #272727;
 }
 
-body.ribbit #MPOuterMost #MPOuter .bg-primary-light .ContentItemHtml.card :not(a:has(i)), 
-body.ribbit #MPOuterMost #MPOuter .bg-primary-light.ContentItemHtml :not(a::has(i)), 
-body.ribbit #MPOuterMost #MPOuter .bg-primary-light .ContentItemHtml :not(a:has(i)), 
-body.ribbit #MPOuterMost #MPOuter .bg-secondary-light.ContentItemHtml :not(a:has(i)), 
-body.ribbit #MPOuterMost #MPOuter .bg-secondary-light .ContentItemHtml :not(a:has(i)), 
-body.ribbit #MPOuterMost #MPOuter .bg-secondary-light .ContentItemHtml.card :not(a:has(i)) {
+body.ribbit #MPOuterMost #MPOuter .bg-primary-light .ContentItemHtml.card *:not(em a),
+body.ribbit #MPOuterMost #MPOuter .bg-primary-light.ContentItemHtml *:not(em a),
+body.ribbit #MPOuterMost #MPOuter .bg-primary-light .ContentItemHtml *:not(em a),
+body.ribbit #MPOuterMost #MPOuter .bg-secondary-light.ContentItemHtml *:not(em a),
+body.ribbit #MPOuterMost #MPOuter .bg-secondary-light .ContentItemHtml *:not(em a),
+body.ribbit #MPOuterMost #MPOuter .bg-secondary-light .ContentItemHtml.card *:not(em a) {
     color: #595959;
-}
-
-body.ribbit #MPOuterMost #MPOuter .bg-primary-light .ContentItemHtml.card a i,
-body.ribbit #MPOuterMost #MPOuter .bg-primary-light.ContentItemHtml a i,
-body.ribbit #MPOuterMost #MPOuter .bg-primary-light .ContentItemHtml a i,
-body.ribbit #MPOuterMost #MPOuter .bg-secondary-light.ContentItemHtml a i,
-body.ribbit #MPOuterMost #MPOuter .bg-secondary-light .ContentItemHtml a i,
-body.ribbit #MPOuterMost #MPOuter .bg-secondary-light .ContentItemHtml.card a i {
-    color: var(--hl-bs--secondary-opposite);
 }
 
 body.ribbit .bg-primary .ContentItemHtml:not(.card) .icon-container *,


### PR DESCRIPTION
Reverting this merge as I see a few issues with the code:

1) There's code that's explicitly setting the colour on primary/secondary light to the text-on-primary/secondary, which is often illegible as it's white on a light colour (lines 1249-1251, 1268-1270). This is then being overwritten with a dark grey colour (lines 1289-1294).

2) The overwriting doesn't appear that it will apply to clickable cards because the ".card :not(a:has(i))" is going to exclude any clickable cards with icons, as those are <a> tags with an icon. @eCM-MDykeman do you have an example of this working in practice?

A better solution would be to remove the code mentioned in #1 above and simplify the code in #2 (possibly removing the reset of the colour, if this is the default text colour or default card text colour).