### PR TITLE
Widget More Link Spacing - TD-78

### DIFF
--- a/code/thrive-design-stylesheet-new.css
+++ b/code/thrive-design-stylesheet-new.css
@@ -4088,7 +4088,7 @@ body.ribbit:not(.interior) .row>div[class*="col-md-"]>div[class*="Content"]:not(
 
 #MPOuterMost #MPOuter .featured-cards div[id*=Main] .SearchResults.HLLandingControl div .Content>ul li:not(.slick-slide),
 #MPOuterMost #MPOuter .event-cards .Content ul li {
-    margin: 0 12px;
+    margin: 0 12px 12px 12px;
     display: flex;
     flex-direction: column;
     padding: 0;


### PR DESCRIPTION
https://higherlogic.atlassian.net/browse/TD-78

The spacing/margin needed for the More links was actually needed on the <li> tags above it like these have on mobile. Tested on Staging site here: https://econversetest.connectedcommunity.org/wds-staging/home/memberhome