### PR TITLE
Widget Text Container mobile fix - TD-88

### DIFF
--- a/code/thrive-design-stylesheet-new.css
+++ b/code/thrive-design-stylesheet-new.css
@@ -6677,7 +6677,7 @@ body.ribbit #edit-event-button-container {
     .home .col-md-6 .HLEventList ul li .col-md-10,
     .memberhome .col-md-6 .HLEventList ul li .col-md-10,
     .col-md-6 .HLRecentBlogs ul li .text-container,
-    .col-md-6 .HLMyDocuments ul li .img-container:not(.no-ajax-image) .text-container {
+    .col-md-6 .HLMyDocuments ul li .img-container:not(.no-ajax-image)+.text-container {
         width: 100%;
         padding-right: 0;
     }


### PR DESCRIPTION
Super quick/easy fix for the mobile text container in the Recent Shared Files List widget (it was missing the "+" in the media query)