### PR TITLE
Team Bio Card popup mobile fix - TD-86

### DIFF
--- a/code/thrive-design-stylesheet-new.css
+++ b/code/thrive-design-stylesheet-new.css
@@ -2079,7 +2079,8 @@ body.ribbit .bio h3 {
     height: 450px;
     width: 800px;
     top: calc(50% - 200px);
-    left: calc(50% - 350px);
+    left: 50%;
+    transform: translateX(-50%);
     border-radius: 4px;
     padding: 40px;
     background: #ffffff;
@@ -6731,6 +6732,11 @@ body.ribbit .suggested-contacts-cards .HL-contact-suggestions .col-md-4 .btn-def
     
     body.ribbit.profile .profile-tabs-toggle:is(:hover, :focus) {
         color: #fff;
+    }
+
+    .bio {
+        height: 350px;
+        width: calc(100% - 30px);
     }
 }
 


### PR DESCRIPTION
The changes on line 2082 and 2083 center align the bio modal popup on all screen sizes. Then the height and width addition in the media query ensures that the bio modal popup is not cutoff on mobile with a gutter on the sides.

https://higherlogic.atlassian.net/browse/TD-86