### PR TITLE
Community specific content with no image alignment - TD-80

### DIFF
--- a/code/thrive-design-stylesheet-new.css
+++ b/code/thrive-design-stylesheet-new.css
@@ -5376,6 +5376,11 @@ body.ribbit.community-pages #MPOuterMost #MPOuter .no-community-html {
     width: 75%;
 }
 
+.summary-edit .Content > .text-container:first-child {
+    width: 100%;
+    padding-right: 0;
+}
+
 /****** tabs ******/
 
 body.ribbit .community-tabs-container-outer {


### PR DESCRIPTION
Was able to find a CSS only solution without requiring JS!

The CSS targets the text-container only if it is the first child in the ".summary-edit .Content" div which it is if there is no image or list (ul) in the Additional HTML.

Because the communities are in main Model site (not the Staging site) I had to test this code in the Override CSS of the main Model site with the [Testing Community](https://econversetest.connectedcommunity.org/communities/community-home?CommunityKey=ec1438b6-35a2-42a1-8677-018fbb9f5f62) - but I removed that code from the Override CSS after I was done!

https://higherlogic.atlassian.net/browse/TD-80