### PR TITLE
Fix double drop shadows - TD-65

### DIFF
--- a/code/thrive-design-stylesheet-new.css
+++ b/code/thrive-design-stylesheet-new.css
@@ -2,6 +2,7 @@
     --ui-default-text: #595959;
     --ui-heading-text: #272727;
     --ui-default-text-small: #666;
+    --card-shadow: 0px 0px 2px 0px rgba(153, 153, 153, 0.25), 0px 2px 4px 0px rgba(0, 0, 0, 0.10);
 }
 
 /************ basics ************/
@@ -1381,7 +1382,7 @@ body.ribbit .card .HLLandingControl,
 body.ribbit .suggested-contacts-cards .HL-contact-suggestions .row ul {
     border-radius: 8px;
     padding: 24px;
-    box-shadow: 0px 0px 2px 0px rgba(153, 153, 153, 0.25), 0px 2px 4px 0px rgba(0, 0, 0, 0.10);
+    box-shadow: var(--card-shadow);
     background: #fff;
     filter: none;
     border: none;
@@ -2217,7 +2218,7 @@ body.ribbit .sponsor a {
     padding: 24px;
     display: flex;
     text-decoration: none;
-    box-shadow: 0px 0px 2px 0px rgba(153, 153, 153, 0.25), 0px 2px 4px 0px rgba(0, 0, 0, 0.10);
+    box-shadow: var(--card-shadow);
     transition: 0.3s;
     flex-direction: column;
     color: #272727;
@@ -3213,6 +3214,10 @@ li.slick-active button::before {
 
 /************ profile card ************/
 
+body.ribbit .ProfileSnippet {
+    box-shadow: var(--card-shadow);
+}
+
 .profile-snippet-card.hl-widget-card.bg-alt-bg5 {
     background-color: var(--hl-bs--primary) !important;
 }
@@ -3404,7 +3409,9 @@ body.ribbit .feed-list .layout-grid-cell .feed-item-row {
 body.ribbit .feed-list .layout-grid-cell .feed-item-row .images-preview {
     border-radius: 8px 8px 0 0;
 }
-body.ribbit .FeedWidget .card, body.ribbit .MicrositeFeedWidget .card {
+body.ribbit .FeedWidget .card,
+body.ribbit .MicrositeFeedWidget .card,
+body.ribbit:not(.interior) .row>div[class*=col-md-]>div.ContentItemReact.FeedWidget .feed-item-row.card {
     border: none;
     box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.10), 0px 0px 2px 0px rgba(153, 153, 153, 0.25);
 }
@@ -4096,7 +4103,7 @@ body.ribbit:not(.interior) .row>div[class*="col-md-"]>div[class*="Content"]:not(
     margin: 8px;
     padding-bottom: 0;
     padding-top: 0;
-    box-shadow: 0px 0px 2px 0px rgba(153, 153, 153, 0.25), 0px 2px 4px 0px rgba(0, 0, 0, 0.10);
+    box-shadow: var(--card-shadow);
 }
 
 .list-tiles .Content ul li .content-row {
@@ -4109,7 +4116,7 @@ body.ribbit:not(.interior) .row>div[class*="col-md-"]>div[class*="Content"]:not(
     display: flex;
     flex-direction: column;
     padding: 0;
-    box-shadow: 0px 0px 2px 0px rgba(153, 153, 153, 0.25), 0px 2px 4px 0px rgba(0, 0, 0, 0.10);
+    box-shadow: var(--card-shadow);
     border: none;
     border-radius: 8px;
     width: 100%;
@@ -5466,11 +5473,25 @@ body.ribbit .community-tabs-container #CommunityTabsContainer.nav.nav-tabs .drop
     margin-top: 0;
 }
 
+/****** disable default Thrive filter drop shadow ******/
+body.ribbit:not(.interior) .row>div[class*=col-md-]>div[class*=Content] .HLLandingControl,
+body.ribbit:not(.interior) .row>div[class*=col-md-]>div.ContentItemReact,
+body.ribbit.interior .QuickLinksWidget,
+body.ribbit.interior .ThreadListWidget,
+body.ribbit.interior .most-active-members-list-view,
+body.ribbit.interior .latest-library-entries-list-view,
+body.ribbit.interior .CommunityEventsList,
+body.ribbit.interior .MyCommunitiesQuickList,
+body.ribbit.interior .RecentBlogs, body.ribbit.interior .RecentlyFollowedContent {
+    -webkit-filter: none;
+    filter: none;
+}
+
 /****** widgets ******/
 
 .groupdetails #MPOuterMost #MPOuter .col-md-4 .HLLandingControl {
     border-radius: 8px;
-    box-shadow: 0px 0px 2px 0px rgba(153, 153, 153, 0.25), 0px 2px 4px 0px rgba(0, 0, 0, 0.10);
+    box-shadow: var(--card-shadow);
     padding: 24px;
 }
 
@@ -5500,8 +5521,7 @@ body.ribbit .community-tabs-container #CommunityTabsContainer.nav.nav-tabs .drop
 body.ribbit .PollTakingContainer .widget-container {
     padding: 16px;
     background-color: var(--hl-bs--bg0);
-    -webkit-filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.25));
-    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.25));
+    box-shadow: var(--card-shadow);
     border: none;
     border-radius: 8px;
 }

--- a/code/thrive-design-stylesheet-new.css
+++ b/code/thrive-design-stylesheet-new.css
@@ -2226,7 +2226,7 @@ body.ribbit .sponsor a {
 
 
 body.ribbit .sponsor a:is(:hover, :focus) {
-    box-shadow: 0px 0px 2px 0px rgba(153, 153, 153, 0.25), 0px 2px 4px 0px rgba(0, 0, 0, 0.10), 0px 0px 16px 0px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--card-shadow), 0px 0px 16px 0px rgba(0, 0, 0, 0.15);
     transition: 0.3s;
 }
 
@@ -2488,7 +2488,7 @@ body.ribbit :not(.no-theme) .navbar-default .navbar-nav>.open>a:focus {
 /* Nav Dropdown */
 
 .navbar-nav>li>.dropdown-menu {
-    box-shadow: 0px 0px 2px 0px rgba(153, 153, 153, 0.25), 0px 2px 4px 0px rgba(0, 0, 0, 0.10), 0px 2px 16px 0px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--card-shadow), 0px 2px 16px 0px rgba(0, 0, 0, 0.15);
     min-width: 221px;
     border-radius: 8px;
     padding: 16px;


### PR DESCRIPTION
https://higherlogic.atlassian.net/browse/TD-65

The changes do the following:

1. Line 5476 - disables the default Thrive filter drop shadow that was adding the second shadow to our Model's designed shadow.
2. Sets a variable card box shadow to the root values and assigns that variable where it corresponded in the styles.
3. Line 3217 - adds the variable box shadow to the Profile Card widget since it was needed after disabling the default Thrive filter drop shadow.
4. Line 3412 - we already had a set specific box shadow on the Activity Feed widget cards, but it was not applying so added an additional target to "body.ribbit:not(.interior) .row>div[class*=col-md-]>div.ContentItemReact.FeedWidget .feed-item-row.card" in order for our box shadow to apply (this was also needed after disabling the default Thrive filter drop shadow).
5. Line 5494 - the Poll widget had a different but very similar shadow so changed it over to the variable box shadow instead for consistency.